### PR TITLE
CPP input in python tutor

### DIFF
--- a/run_cpp_backend.py
+++ b/run_cpp_backend.py
@@ -17,11 +17,14 @@ if not DN:
     DN = '.' # so that we always have an executable path like ./usercode.exe
 USER_PROGRAM = sys.argv[1] # string containing the program to be run
 LANG = sys.argv[2] # 'c' for C or 'cpp' for C++
+USER_INPUT = ""
 
-prettydump = False
+prettydump = ('--prettydump' in sys.argv)
+
 if len(sys.argv) > 3:
-    if sys.argv[3] == '--prettydump':
-        prettydump = True
+    thrid_argument_is_input = (sys.argv[3] != '--prettydump')
+    if thrid_argument_is_input:
+        USER_INPUT = sys.argv[3]
 
 
 if LANG == 'c':
@@ -66,7 +69,9 @@ if gcc_retcode == 0:
                         '--source-filename=' + FN,
                         '--trace-filename=' + VGTRACE_PATH,
                         EXE_PATH],
-                       stdout=PIPE, stderr=PIPE)
+                       stdout=PIPE, stderr=PIPE, stdin=PIPE)
+
+    valgrind_p.stdin.write(USER_INPUT)
     (valgrind_stdout, valgrind_stderr) = valgrind_p.communicate()
     valgrind_retcode = valgrind_p.returncode
 


### PR DESCRIPTION
This changes allow the "run_cpp_backend.py" script to receive user input as a console parameter and use it as the stdin for the user code under execution.

valgrind debugger redirects stdin all the way to the user program, so, if we redirect the user input parameter into the debugger stdin it will be used as the stdin for the original problem

@0xDCA @larranaga @milderhc 
Could you guys take a look at it?